### PR TITLE
Corrige error de conexión a MongoDB manteniendo la conexión abierta

### DIFF
--- a/src/scripts/init-mongo.js
+++ b/src/scripts/init-mongo.js
@@ -67,10 +67,6 @@ const initMongo = async () => {
     } else {
       console.log('La base de datos ya contiene datos, omitiendo inicialización');
     }
-
-    // Cerrar conexión
-    await mongoose.connection.close();
-    console.log('Conexión a MongoDB cerrada');
   } catch (error) {
     console.error('Error al inicializar la base de datos:', error);
   }


### PR DESCRIPTION
# Corrección de error de conexión a MongoDB

Este PR soluciona el problema de conexión a MongoDB que impedía el funcionamiento correcto de la API.

## Problema
La aplicación mostraba el error "Client must be connected before running operations" porque la conexión a MongoDB se cerraba después de inicializar los datos, pero antes de que las rutas de la API pudieran utilizarla.

## Solución
Se eliminó el código que cerraba la conexión a MongoDB en el archivo `init-mongo.js`, permitiendo que la conexión permanezca abierta para ser utilizada por las rutas de la API.

## Cambios realizados
- Eliminado el cierre de conexión en el script de inicialización
- Mantenida la conexión abierta para uso de la API

## Cómo probar
1. Ejecutar `docker-compose up`
2. Verificar que la API responde correctamente en http://localhost:3000/api/books
3. Comprobar que los datos se cargan y se pueden consultar sin errores de conexión